### PR TITLE
Make secret type be overridable with default of Opaque

### DIFF
--- a/src/main/java/net/stickycode/plugin/kuuty/KuutyGenerateSecretMojo.java
+++ b/src/main/java/net/stickycode/plugin/kuuty/KuutyGenerateSecretMojo.java
@@ -26,7 +26,7 @@ public class KuutyGenerateSecretMojo
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    KuutySecretProcessor processor = new KuutySecretProcessor(name, namespace);
+    KuutySecretProcessor processor = new KuutySecretProcessor(name, namespace, type);
     collector.processSourceDirectory(sourceDirectory.toPath(), processor);
     generator.write(processor.getResource(), outputDirectory.toPath().resolve(outputContextPath), filename);
   }

--- a/src/main/java/net/stickycode/plugin/kuuty/KuutyMojo.java
+++ b/src/main/java/net/stickycode/plugin/kuuty/KuutyMojo.java
@@ -19,6 +19,9 @@ public abstract class KuutyMojo extends AbstractMojo {
   @Parameter
   String namespace;
 
+  @Parameter(defaultValue = "Opaque", required = true)
+  String type;
+
   /**
    * Where to write the generated resources
    */

--- a/src/main/java/net/stickycode/plugin/kuuty/KuutySecretProcessor.java
+++ b/src/main/java/net/stickycode/plugin/kuuty/KuutySecretProcessor.java
@@ -8,15 +8,15 @@ public class KuutySecretProcessor
 
   private final IoK8sApiCoreV1Secret secret;
 
-  public KuutySecretProcessor(String name, String namespace) {
-    this.secret = createSecret(name, namespace);
+  public KuutySecretProcessor(String name, String namespace, String type) {
+    this.secret = createSecret(name, namespace, type);
   }
 
-  private IoK8sApiCoreV1Secret createSecret(String name, String namespace) {
+  private IoK8sApiCoreV1Secret createSecret(String name, String namespace, String type) {
     IoK8sApiCoreV1Secret config = new IoK8sApiCoreV1Secret();
     config.setApiVersion("v1");
     config.setKind("Secret");
-    config.setType("Opaque");
+    config.setType(type);
     IoK8sApimachineryPkgApisMetaV1ObjectMeta metadata = new IoK8sApimachineryPkgApisMetaV1ObjectMeta();
     metadata.setName(name);
     metadata.setNamespace(namespace);

--- a/src/test/java/net/stickycode/plugin/kuuty/KuutyResourceGeneratorTest.java
+++ b/src/test/java/net/stickycode/plugin/kuuty/KuutyResourceGeneratorTest.java
@@ -68,7 +68,7 @@ public class KuutyResourceGeneratorTest {
 
   @Test
   public void writeSecret() throws IOException {
-    KuutySecretProcessor other = new KuutySecretProcessor("thesecret", null);
+    KuutySecretProcessor other = new KuutySecretProcessor("thesecret", null, "Opaque");
     other.processTemplate("one.properties", "a=value");
     other.processTemplate("some.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
       "<configuration>\n" +
@@ -95,7 +95,7 @@ public class KuutyResourceGeneratorTest {
 
   @Test
   public void writeSecretWithNamespace() throws IOException {
-    KuutySecretProcessor other = new KuutySecretProcessor("thesecret", "thenamespace");
+    KuutySecretProcessor other = new KuutySecretProcessor("thesecret", "thenamespace", "fakeType");
     other.processTemplate("one.properties", "a=value");
     other.processTemplate("some.xml", "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
       "<configuration>\n" +
@@ -117,7 +117,7 @@ public class KuutyResourceGeneratorTest {
       "    <configuration>\n" +
       "      <root level=\"info\" />\n" +
       "    </configuration>\n" +
-      "type: Opaque\n");
+      "type: fakeType\n");
 
   }
 


### PR DESCRIPTION
It was hard coded to Opaque. And adjust tests to suit. Mojo defaulting behaviour assumed to be good and not covered by existing tests and new ones not added.

Branch name for lols because you can't usually do that! :-D FF merge/push and it won't be recorded except here... :-p