### PR TITLE
Upgrade depends and tiles:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </properties>
 
   <prerequisites>
-    <maven>3.5.0</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <dependencies>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>[3.5.1]</version>
+      <version>[3.6.0]</version>
       <scope>provided</scope>
     </dependency>
 
@@ -64,11 +64,14 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>[3.6.3]</version>
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>[3.6.3]</version>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>
@@ -78,20 +81,20 @@
       <plugin>
         <groupId>io.repaint.maven</groupId>
         <artifactId>tiles-maven-plugin</artifactId>
-        <version>2.17</version>
+        <version>2.34</version>
         <configuration>
           <tiles>
-            <tile>net.stickycode.tile:sticky-tile-release:[1,2)</tile>
+            <tile>net.stickycode.tile:sticky-tile-release:[2,3)</tile>
           </tiles>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.9.0</version>
       </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.5.1</version>
         <configuration>
           <projectsDirectory>src/it</projectsDirectory>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -118,7 +121,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>purge-local-dependencies</id>


### PR DESCRIPTION
maven 3.9.2 is harsh for anything out in the plugin definition so use provided scope
require the usage of at leave maven 3.6.3 its the oldest currently supported maven version
